### PR TITLE
feat: add connection demo script for websocket integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ Quick start examples for Lexmount Python SDK.
 - Print the `inspect_url` for manual inspection
 - Wait for user input before closing the session
 
+### connection_demo.py - Direct Connection Demo
+- Build a direct websocket URL from `LEXMOUNT_BASE_URL`
+- Connect through `/connection?project_id=...&api_key=...`
+- Visit `https://example.com` and save `connection_demo.png`
+
 ### session_downloads.py - Session Downloads Demo
 - Explicitly configure `Browser.setDownloadBehavior` to `/config/Downloads`
 - Trigger a file download in the remote browser
@@ -62,5 +67,6 @@ python3 light_demo.py        # Light browser demo
 python3 extension_basic.py   # Extension demo
 python3 proxy_demo.py        # Proxy demo
 python3 inspect_url_demo.py  # Inspect URL demo
+python3 connection_demo.py   # Direct connection demo
 python3 session_downloads.py # Session downloads demo
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -32,6 +32,11 @@
 - 打印 `inspect_url` 供用户手动打开检查
 - 等待用户输入后再关闭会话
 
+### connection_demo.py - 直连 websocket 演示
+- 根据 `LEXMOUNT_BASE_URL` 组装直连 websocket 地址
+- 通过 `/connection?project_id=...&api_key=...` 连接
+- 访问 `https://example.com` 并保存 `connection_demo.png`
+
 ---
 
 ## 🚀 快速开始
@@ -56,4 +61,5 @@ python3 light_demo.py        # 轻量浏览器演示
 python3 extension_basic.py   # 插件演示
 python3 proxy_demo.py        # 代理演示
 python3 inspect_url_demo.py  # Inspect URL 演示
+python3 connection_demo.py   # 直连 websocket 演示
 ```

--- a/connection_demo.py
+++ b/connection_demo.py
@@ -1,0 +1,46 @@
+from urllib.parse import urlencode, urlparse, urlunparse
+
+from dotenv import load_dotenv
+
+from lexmount import Lexmount
+from playwright.sync_api import Playwright, sync_playwright
+
+load_dotenv(override=True)
+
+
+def build_connection_url(client: Lexmount) -> str:
+    parsed = urlparse(client.base_url)
+    scheme = "wss" if parsed.scheme == "https" else "ws"
+    query = urlencode(
+        {
+            "project_id": client.project_id,
+            "api_key": client.api_key,
+        }
+    )
+    return urlunparse((scheme, parsed.netloc, "/connection", "", query, ""))
+
+
+def run(playwright: Playwright) -> None:
+    client = Lexmount()
+    connection_url = build_connection_url(client)
+
+    print(f"connection_url: {connection_url}")
+
+    browser = playwright.chromium.connect_over_cdp(connection_url)
+    context = browser.contexts[0]
+    page = context.pages[0] if context.pages else context.new_page()
+
+    page.goto("https://example.com")
+    page_title = page.title()
+    assert page_title == "Example Domain", (
+        "Page title is not 'Example Domain', "
+        f"it is '{page_title}'"
+    )
+    page.screenshot(path="connection_demo.png")
+
+    input("Press Enter to continue...")
+
+
+if __name__ == "__main__":
+    with sync_playwright() as playwright:
+        run(playwright)


### PR DESCRIPTION
- Introduced `connection_demo.py` to demonstrate building a direct websocket URL using `LEXMOUNT_BASE_URL`.
- The script connects to a specified project and API key, navigates to `https://example.com`, and captures a screenshot.
- Updated README files to include instructions for running the new demo.