### PR TITLE
Align Python quickstart context fork example with input id flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,9 @@ Quick start examples for Lexmount Python SDK.
 - Wait for user input before closing the session
 
 ### context_fork.py - Context Fork Demo
-- Create a source context
+- Accept an existing source `context_id`
 - Fork it into a new context
-- Query the forked context details
-- Clean up both source and forked contexts
+- Print the forked context id
 
 ### connection_demo.py - Direct Connection Demo
 - Build a direct websocket URL from `LEXMOUNT_BASE_URL`
@@ -70,7 +69,7 @@ cp .env.example .env
 # 4. Run examples
 python3 demo.py              # Basic demo
 python3 light_demo.py        # Light browser demo
-python3 context_fork.py      # Context fork demo
+python3 context_fork.py <context_id>  # Context fork demo
 python3 extension_basic.py   # Extension demo
 python3 proxy_demo.py        # Proxy demo
 python3 inspect_url_demo.py  # Inspect URL demo

--- a/README.zh.md
+++ b/README.zh.md
@@ -33,10 +33,9 @@
 - 等待用户输入后再关闭会话
 
 ### context_fork.py - Context Fork 演示
-- 创建 source context
+- 传入一个已有的 source `context_id`
 - 基于 source fork 出新的 context
-- 查询 fork 后 context 的详情
-- 清理 source 和 forked context
+- 打印 fork 后的新 id
 
 ### connection_demo.py - 直连 websocket 演示
 - 根据 `LEXMOUNT_BASE_URL` 组装直连 websocket 地址
@@ -64,7 +63,7 @@ cp .env.example .env
 # 4. 运行示例
 python3 demo.py              # 基础演示
 python3 light_demo.py        # 轻量浏览器演示
-python3 context_fork.py      # Context Fork 演示
+python3 context_fork.py <context_id>  # Context Fork 演示
 python3 extension_basic.py   # 插件演示
 python3 proxy_demo.py        # 代理演示
 python3 inspect_url_demo.py  # Inspect URL 演示

--- a/context_fork.py
+++ b/context_fork.py
@@ -2,11 +2,11 @@
 Context fork quickstart example.
 
 This example demonstrates:
-- Creating a source context
+- Accepting an existing source context id
 - Forking it into a new context
-- Querying the forked context details
-- Cleaning up both source and forked contexts
+- Printing the forked context id
 """
+import argparse
 from dotenv import load_dotenv
 
 load_dotenv(override=True)
@@ -17,29 +17,19 @@ client = Lexmount()
 
 
 def main():
-    source = None
-    forked = None
+    parser = argparse.ArgumentParser(description="Fork an existing context and print the new context id")
+    parser.add_argument("context_id", help="Existing source context id")
+    args = parser.parse_args()
 
     try:
-        source = client.contexts.create(metadata={"scenario": "quickstart-context-fork"})
-        print(f"Source context created: {source.id}")
-
-        forked = client.contexts.fork(source.id)
-        print(f"Forked context created: {forked.id}")
-
-        details = client.contexts.get(forked.id)
-        print(f"Forked context status: {details.status}")
+        forked = client.contexts.fork(args.context_id)
+        print(f"Forked context id: {forked.id}")
     except ContextLockedError as error:
         print(f"Source context is locked: {error}")
         raise
     except ContextNotFoundError as error:
         print(f"Source context not found: {error}")
         raise
-    finally:
-        if forked is not None:
-            client.contexts.delete(forked.id)
-        if source is not None:
-            client.contexts.delete(source.id)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary\n- change context fork quickstart to accept an existing context id\n- print only the forked id\n- remove cleanup/delete actions from the example\n- align README docs with the new example flow\n