### PR TITLE
feat: add python session targets quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ Quick start examples for Lexmount Python SDK.
 - Print the `inspect_url` for manual inspection
 - Wait for user input before closing the session
 
+### session_targets.py - Session Targets Demo
+- Create a browser session
+- Query `/json` targets through the SDK
+- Print each target's `inspectUrl`, page URL, and websocket URL
+
 ### context_fork.py - Context Fork Demo
 - Accept an existing source `context_id`
 - Fork it into a new context
@@ -78,6 +83,7 @@ python3 context_fork.py <context_id>  # Context fork demo
 python3 extension_basic.py   # Extension demo
 python3 proxy_demo.py        # Proxy demo
 python3 inspect_url_demo.py  # Inspect URL demo
+python3 session_targets.py   # Session targets demo
 python3 connection_demo.py   # Direct connection demo
 python3 new_page_repro.py --browser-mode normal  # Reproduce new_page issue
 python3 session_downloads.py # Session downloads demo

--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ Quick start examples for Lexmount Python SDK.
 - Connect through `/connection?project_id=...&api_key=...`
 - Visit `https://example.com` and save `connection_demo.png`
 
+### new_page_repro.py - new_page Repro Demo
+- Create a session in `normal` or `light` mode
+- Connect over CDP with Playwright
+- Attempt `context.new_page()` multiple times and print the result
+
 ### session_downloads.py - Session Downloads Demo
 - Explicitly configure `Browser.setDownloadBehavior` to `/config/Downloads`
 - Trigger a file download in the remote browser
@@ -74,5 +79,6 @@ python3 extension_basic.py   # Extension demo
 python3 proxy_demo.py        # Proxy demo
 python3 inspect_url_demo.py  # Inspect URL demo
 python3 connection_demo.py   # Direct connection demo
+python3 new_page_repro.py --browser-mode normal  # Reproduce new_page issue
 python3 session_downloads.py # Session downloads demo
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -32,6 +32,11 @@
 - 打印 `inspect_url` 供用户手动打开检查
 - 等待用户输入后再关闭会话
 
+### session_targets.py - Session Targets 演示
+- 创建浏览器会话
+- 通过 SDK 查询 `/json` target 列表
+- 打印每个 target 的 `inspectUrl`、页面 URL 和 websocket URL
+
 ### context_fork.py - Context Fork 演示
 - 传入一个已有的 source `context_id`
 - 基于 source fork 出新的 context
@@ -67,5 +72,6 @@ python3 context_fork.py <context_id>  # Context Fork 演示
 python3 extension_basic.py   # 插件演示
 python3 proxy_demo.py        # 代理演示
 python3 inspect_url_demo.py  # Inspect URL 演示
+python3 session_targets.py   # Session targets 演示
 python3 connection_demo.py   # 直连 websocket 演示
 ```

--- a/new_page_repro.py
+++ b/new_page_repro.py
@@ -1,0 +1,65 @@
+"""
+Temporary repro script for multi-tab creation via Playwright CDP.
+
+This script is intended to verify whether `context.new_page()` works
+correctly for different browser modes.
+"""
+import argparse
+from dotenv import load_dotenv
+
+load_dotenv(override=True)
+
+from lexmount import Lexmount
+from playwright.sync_api import sync_playwright
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Reproduce context.new_page() behavior for a given browser mode"
+    )
+    parser.add_argument(
+        "--browser-mode",
+        default="normal",
+        choices=["normal", "light"],
+        help="Browser mode to test (default: normal)",
+    )
+    parser.add_argument(
+        "--pages",
+        type=int,
+        default=2,
+        help="How many new pages to attempt creating (default: 2)",
+    )
+    args = parser.parse_args()
+
+    client = Lexmount()
+    session = client.sessions.create(browser_mode=args.browser_mode)
+    print(f"session_id: {session.id}")
+    print(f"browser_mode: {args.browser_mode}")
+    print(f"connect_url: {session.connect_url}")
+
+    try:
+        with sync_playwright() as playwright:
+            browser = playwright.chromium.connect_over_cdp(session.connect_url)
+            try:
+                context = browser.contexts[0] if browser.contexts else browser.new_context()
+
+                print(f"existing_contexts: {len(browser.contexts)}")
+                print(f"existing_pages: {len(context.pages)}")
+
+                for index in range(args.pages):
+                    try:
+                        page = context.new_page()
+                        print(f"new_page[{index}] ok: {page.url}")
+                        page.close()
+                    except Exception as error:
+                        print(f"new_page[{index}] failed: {error}")
+                        raise
+            finally:
+                browser.close()
+    finally:
+        if hasattr(session, "close"):
+            session.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Lexmount SDK
-lexmount>=0.4.8
+lexmount>=0.4.9
 
 # Browser automation
 playwright>=1.40.0

--- a/session_targets.py
+++ b/session_targets.py
@@ -1,0 +1,37 @@
+from dotenv import load_dotenv
+
+from lexmount import Lexmount
+
+load_dotenv(override=True)
+
+
+def main() -> None:
+    client = Lexmount()
+    session = client.sessions.create()
+
+    try:
+        print(f"session_id: {session.id}")
+        print("Listing session targets...")
+
+        targets = client.sessions.list_targets(session.id)
+        print(f"Found {len(targets)} targets\n")
+
+        for target in targets:
+            print(f"target_id: {target.id}")
+            print(f"title: {target.title}")
+            print(f"type: {target.type}")
+            print(f"url: {target.url}")
+            print(f"inspectUrl: {target.inspectUrl or 'N/A'}")
+            print(
+                "webSocketDebuggerUrl: "
+                f"{target.webSocketDebuggerUrlTransformed or target.webSocketDebuggerUrl or 'N/A'}"
+            )
+            print()
+        input("Press Enter to continue...")
+    finally:
+        client.sessions.delete(session_id=session.id)
+        client.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary\n- add Python quickstart for session target listing\n- document the new example in README and README.zh\n- bump quickstart dependency to lexmount>=0.4.9\n\n## Validation\n- python3 -m py_compile session_targets.py