### PR TITLE
fix: support older python type hints

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -1,4 +1,5 @@
 import argparse
+from typing import Optional
 
 from dotenv import load_dotenv
 from lexmount import Lexmount
@@ -7,13 +8,13 @@ from playwright.sync_api import Playwright, sync_playwright
 load_dotenv(override=True)
 
 
-def build_client(region: str | None) -> Lexmount:
+def build_client(region: Optional[str]) -> Lexmount:
     if region:
         return Lexmount(region=region)
     return Lexmount()
 
 
-def run(playwright: Playwright, region: str | None = None) -> None:
+def run(playwright: Playwright, region: Optional[str] = None) -> None:
     lm = build_client(region)
 
     with lm.sessions.create() as session:

--- a/extension_list_get.py
+++ b/extension_list_get.py
@@ -10,6 +10,7 @@ This example demonstrates:
 import argparse
 import sys
 from pathlib import Path
+from typing import Optional
 
 from dotenv import load_dotenv
 from lexmount import APIError, Lexmount, set_log_level
@@ -62,7 +63,7 @@ def get_extension_details(extension_id: str):
         return None
 
 
-def upload_extension(file_path: str, name: str | None = None):
+def upload_extension(file_path: str, name: Optional[str] = None):
     """Upload an extension archive."""
     archive_path = Path(file_path).expanduser().resolve()
     if not archive_path.exists():


### PR DESCRIPTION
## Summary
- replace Python 3.10 union type hints with `typing.Optional`
- fix quickstart runtime failure on Python versions that do not support `str | None`
- update the same pattern in `extension_list_get.py`

## Validation
- Python 3.9 AST parse check for `demo.py` and `extension_list_get.py`
- `python3 -m py_compile demo.py extension_list_get.py`
- `git diff --check`
