### PR TITLE
Add custom image quickstart demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Quick start examples for Lexmount Python SDK.
 - Print each target's `inspectUrl`, page URL, and websocket URL
 
 ### catalog_info.py - Catalog Info Demo
-- Uses `lexmount==0.5.1`
+- Uses the SDK version from `requirements.txt`
 - Query the public endpoint catalog through `client.catalog_info()`
 - Print available regions, host, and endpoint IPs
 
@@ -51,6 +51,11 @@ Quick start examples for Lexmount Python SDK.
 - Build a direct websocket URL from `LEXMOUNT_BASE_URL`
 - Connect through `/connection?project_id=...&api_key=...`
 - Visit `https://example.com` and save `connection_demo.png`
+
+### custom_image_demo.py - Custom Image Demo
+- Create a browser session with `custom_image_id`
+- Accept `--custom_image_id` from the command line
+- Connect to the session and verify the browser can open a page
 
 ### session_downloads.py - Session Downloads Demo
 - Explicitly configure `Browser.setDownloadBehavior` to `/config/Downloads`
@@ -86,5 +91,6 @@ python3 inspect_url_demo.py  # Inspect URL demo
 python3 session_targets.py   # Session targets demo
 python3 catalog_info.py      # Public endpoint catalog demo
 python3 connection_demo.py   # Direct connection demo
+python3 custom_image_demo.py --custom_image_id code.lexmount.net/neng/chrome:tag
 python3 session_downloads.py # Session downloads demo
 ```

--- a/README.zh.md
+++ b/README.zh.md
@@ -38,7 +38,7 @@
 - 打印每个 target 的 `inspectUrl`、页面 URL 和 websocket URL
 
 ### catalog_info.py - Catalog Info 演示
-- 使用 `lexmount==0.5.1`
+- 使用 `requirements.txt` 中的 SDK 版本
 - 通过 `client.catalog_info()` 查询 public endpoint catalog
 - 打印可用 region、host 和 endpoint IP
 
@@ -51,6 +51,11 @@
 - 根据 `LEXMOUNT_BASE_URL` 组装直连 websocket 地址
 - 通过 `/connection?project_id=...&api_key=...` 连接
 - 访问 `https://example.com` 并保存 `connection_demo.png`
+
+### custom_image_demo.py - 自定义镜像演示
+- 使用 `custom_image_id` 创建浏览器会话
+- 支持从命令行传入 `--custom_image_id`
+- 连接会话并验证浏览器可以打开页面
 
 ---
 
@@ -80,4 +85,5 @@ python3 inspect_url_demo.py  # Inspect URL 演示
 python3 session_targets.py   # Session targets 演示
 python3 catalog_info.py      # Public endpoint catalog 演示
 python3 connection_demo.py   # 直连 websocket 演示
+python3 custom_image_demo.py --custom_image_id code.lexmount.net/neng/chrome:tag
 ```

--- a/custom_image_demo.py
+++ b/custom_image_demo.py
@@ -1,0 +1,53 @@
+import argparse
+from typing import Optional
+
+from dotenv import load_dotenv
+from lexmount import Lexmount
+from playwright.sync_api import Playwright, sync_playwright
+
+load_dotenv(override=True)
+
+
+def build_client(region: Optional[str]) -> Lexmount:
+    if region:
+        return Lexmount(region=region)
+    return Lexmount()
+
+
+def run(playwright: Playwright, custom_image_id: str, region: Optional[str] = None) -> None:
+    lm = build_client(region)
+
+    with lm.sessions.create(custom_image_id=custom_image_id) as session:
+        print(f"Session created with custom image: {session.session_id}")
+
+        chromium = playwright.chromium
+        browser = chromium.connect_over_cdp(session.connect_url)
+        context = browser.contexts[0]
+        page = context.pages[0]
+
+        page.goto("https://browser.lexmount.cn/")
+        print(f"Page title: {page.title()}")
+
+        page.close()
+        browser.close()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a Lexmount session with custom_image_id.")
+    parser.add_argument(
+        "--custom_image_id",
+        required=True,
+        help="Custom browser image id, for example code.lexmount.net/neng/chrome:tag.",
+    )
+    parser.add_argument(
+        "--region",
+        default=None,
+        help="Optional catalog region id, for example office-beijing. Omit to use the default region.",
+    )
+    return parser.parse_args()
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    with sync_playwright() as playwright:
+        run(playwright, custom_image_id=args.custom_image_id, region=args.region)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Lexmount SDK
-lexmount==0.5.4
+lexmount==0.5.5
 
 # Browser automation
 playwright>=1.40.0


### PR DESCRIPTION
## Summary
- add `custom_image_demo.py` that accepts `--custom_image_id` and creates a session with `custom_image_id`
- bump quickstart dependency to `lexmount==0.5.5`
- document the new example in English and Chinese READMEs

## Validation
- `venv/bin/python -m py_compile custom_image_demo.py demo.py light_demo.py`