### PR TITLE
chore: update lexmount sdk dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Lexmount SDK
-lexmount==0.5.7
+lexmount==0.5.9
 
 # Browser automation
 playwright>=1.40.0


### PR DESCRIPTION
Update quickstart to use lexmount Python SDK 0.5.9.